### PR TITLE
Background Fix + Scrollbar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -10,8 +10,12 @@ body {
   color: #333;
   font-size: 14px;
   font-weight: 400;
-  background: #fff;
+  background: #333;
   overflow-x: hidden;
+}
+
+body::-webkit-scrollbar {
+  display: none;
 }
 
 html {


### PR DESCRIPTION
- Made the scrollbar invisible but still usable via webkit.
- Made the page body color match the game section. This gets rid of issues on lower resolutions where the white page background could be seen when scrolling with the parallax.

These two changes make the site appear a lot cleaner, especially on resolutions that are not the 1920x1080 standard.
![beforeafter](https://github.com/MCAlagaesiaNetwork/Paolini/assets/26174270/49b602e7-fd08-4cb7-b070-2d2037da1423)
